### PR TITLE
Blog CI/CD 자동화

### DIFF
--- a/.github/workflows/deploy_blog.yml
+++ b/.github/workflows/deploy_blog.yml
@@ -1,3 +1,4 @@
+# .github/workflows/deploy-blog.yml
 name: Deploy Blog to AWS
 
 on:
@@ -9,7 +10,6 @@ on:
 env:
   NODE_VERSION: '18'
   BUN_VERSION: 'latest'
-  APP_NAME: 'blog'
 
 jobs:
   build-and-deploy:
@@ -18,33 +18,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'bun'
-
       - name: Install dependencies
         run: bun install
-
-      - name: Nx Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.nx
-            node_modules/.cache/nx
-          key: ${{ runner.os }}-nx-blog-${{ hashFiles('**/bun.lockb') }}
-          restore-keys: |
-            ${{ runner.os }}-nx-blog-
-            ${{ runner.os }}-nx-
 
       # blog 앱이 존재하는지 확인
       - name: Check if blog app exists
@@ -103,12 +84,9 @@ jobs:
         run: |
           echo "🚀 Deploying blog to S3..."
 
-          # S3 동기화 실행
           aws s3 sync dist/apps/blog s3://${{ secrets.S3_BUCKET_NAME }} \
             --delete \
-            --exact-timestamps \
-            --cache-control "public,max-age=3600" \
-            --metadata-directive REPLACE
+            --exact-timestamps
 
           echo "✅ Blog deployed to S3"
 
@@ -117,22 +95,11 @@ jobs:
         run: |
           echo "🔄 Invalidating CloudFront cache..."
 
-          INVALIDATION_ID=$(aws cloudfront create-invalidation \
+          aws cloudfront create-invalidation \
             --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
-            --paths "/*" \
-            --query 'Invalidation.Id' \
-            --output text)
+            --paths "/*"
 
-          echo "✅ CloudFront invalidation created: $INVALIDATION_ID"
-          echo "⏳ Cache invalidation may take 10-15 minutes to complete"
-
-      # 배포 성공 알림
-      - name: Deployment success notification
-        if: env.BLOG_EXISTS == 'true' && github.ref == 'refs/heads/blog' && github.event_name == 'push'
-        run: |
-          echo "🎉 Blog deployment completed successfully!"
-          echo "🌐 Your blog should be available at: https://${{ secrets.S3_BUCKET_NAME }}"
-          echo "⏰ CloudFront cache invalidation is in progress..."
+          echo "✅ CloudFront invalidation created"
 
   # 테스트 작업 (PR용)
   test-blog:
@@ -150,19 +117,6 @@ jobs:
 
       - name: Install dependencies
         run: bun install
-
-      # blog 앱 테스트
-      - name: Run blog tests
-        run: |
-          echo "🧪 Testing blog application..."
-
-          # 테스트가 설정되어 있는 경우 실행
-          if bunx nx test blog --help > /dev/null 2>&1; then
-            echo "Running blog tests..."
-            bunx nx test blog
-          else
-            echo "ℹ️ No tests configured for blog app"
-          fi
 
       - name: Run blog linting
         run: |

--- a/.github/workflows/deploy_blog.yml
+++ b/.github/workflows/deploy_blog.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           echo "🚀 Deploying blog to S3..."
 
-          aws s3 sync dist/apps/blog s3://${{ secrets.S3_BUCKET_NAME }} \
+          aws s3 sync dist/apps/blog s3://${{ secrets.BLOG_S3_BUCKET_NAME }} \
             --delete \
             --exact-timestamps
 
@@ -96,7 +96,7 @@ jobs:
           echo "🔄 Invalidating CloudFront cache..."
 
           aws cloudfront create-invalidation \
-            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --distribution-id ${{ secrets.BLOG_CLOUDFRONT_DISTRIBUTION_ID }} \
             --paths "/*"
 
           echo "✅ CloudFront invalidation created"

--- a/.github/workflows/deploy_blog.yml
+++ b/.github/workflows/deploy_blog.yml
@@ -1,0 +1,190 @@
+name: Deploy Blog to AWS
+
+on:
+  push:
+    branches: [blog]
+  pull_request:
+    branches: [blog]
+
+env:
+  NODE_VERSION: '18'
+  BUN_VERSION: 'latest'
+  APP_NAME: 'blog'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'bun'
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Nx Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.nx
+            node_modules/.cache/nx
+          key: ${{ runner.os }}-nx-blog-${{ hashFiles('**/bun.lockb') }}
+          restore-keys: |
+            ${{ runner.os }}-nx-blog-
+            ${{ runner.os }}-nx-
+
+      # blog 앱이 존재하는지 확인
+      - name: Check if blog app exists
+        run: |
+          if bunx nx show project blog > /dev/null 2>&1; then
+            echo "✅ Blog app found"
+            echo "BLOG_EXISTS=true" >> $GITHUB_ENV
+          else
+            echo "❌ Blog app not found"
+            echo "Available apps:"
+            bunx nx show projects
+            echo "BLOG_EXISTS=false" >> $GITHUB_ENV
+            exit 1
+          fi
+
+      # blog 앱만 빌드
+      - name: Build blog application
+        if: env.BLOG_EXISTS == 'true'
+        run: |
+          echo "🏗️ Building blog application..."
+          bunx nx build blog
+
+          # 빌드 결과 확인
+          echo "📁 Build output:"
+          ls -la dist/apps/blog/ || ls -la apps/blog/doc_build/ || echo "Build output not found"
+
+          # RSPress 빌드 결과 처리 (필요한 경우)
+          if [ -d "apps/blog/doc_build" ]; then
+            echo "📚 RSPress build detected, copying to standard dist location"
+            mkdir -p dist/apps/blog
+            cp -r apps/blog/doc_build/* dist/apps/blog/
+            echo "✅ RSPress content copied"
+          fi
+
+          # 최종 빌드 결과 확인
+          if [ -d "dist/apps/blog" ] && [ "$(ls -A dist/apps/blog)" ]; then
+            echo "✅ Blog build successful"
+            echo "📄 Build contents:"
+            ls -la dist/apps/blog/
+          else
+            echo "❌ Blog build failed - no output found"
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        if: env.BLOG_EXISTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      # blog 브랜치에 푸시할 때만 배포 (PR은 제외)
+      - name: Deploy blog to S3
+        if: env.BLOG_EXISTS == 'true' && github.ref == 'refs/heads/blog' && github.event_name == 'push'
+        run: |
+          echo "🚀 Deploying blog to S3..."
+
+          # S3 동기화 실행
+          aws s3 sync dist/apps/blog s3://${{ secrets.S3_BUCKET_NAME }} \
+            --delete \
+            --exact-timestamps \
+            --cache-control "public,max-age=3600" \
+            --metadata-directive REPLACE
+
+          echo "✅ Blog deployed to S3"
+
+      - name: Invalidate CloudFront cache
+        if: env.BLOG_EXISTS == 'true' && github.ref == 'refs/heads/blog' && github.event_name == 'push'
+        run: |
+          echo "🔄 Invalidating CloudFront cache..."
+
+          INVALIDATION_ID=$(aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/*" \
+            --query 'Invalidation.Id' \
+            --output text)
+
+          echo "✅ CloudFront invalidation created: $INVALIDATION_ID"
+          echo "⏳ Cache invalidation may take 10-15 minutes to complete"
+
+      # 배포 성공 알림
+      - name: Deployment success notification
+        if: env.BLOG_EXISTS == 'true' && github.ref == 'refs/heads/blog' && github.event_name == 'push'
+        run: |
+          echo "🎉 Blog deployment completed successfully!"
+          echo "🌐 Your blog should be available at: https://${{ secrets.S3_BUCKET_NAME }}"
+          echo "⏰ CloudFront cache invalidation is in progress..."
+
+  # 테스트 작업 (PR용)
+  test-blog:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install
+
+      # blog 앱 테스트
+      - name: Run blog tests
+        run: |
+          echo "🧪 Testing blog application..."
+
+          # 테스트가 설정되어 있는 경우 실행
+          if bunx nx test blog --help > /dev/null 2>&1; then
+            echo "Running blog tests..."
+            bunx nx test blog
+          else
+            echo "ℹ️ No tests configured for blog app"
+          fi
+
+      - name: Run blog linting
+        run: |
+          echo "🔍 Linting blog application..."
+
+          # 린팅이 설정되어 있는 경우 실행
+          if bunx nx lint blog --help > /dev/null 2>&1; then
+            echo "Running blog linting..."
+            bunx nx lint blog
+          else
+            echo "ℹ️ No linting configured for blog app"
+          fi
+
+      - name: Build check for blog
+        run: |
+          echo "🏗️ Build check for blog application..."
+          bunx nx build blog
+
+          # 빌드 결과 확인
+          if [ -d "dist/apps/blog" ] || [ -d "apps/blog/doc_build" ]; then
+            echo "✅ Blog build check passed"
+          else
+            echo "❌ Blog build check failed"
+            exit 1
+          fi


### PR DESCRIPTION
🚀 바뀐점
AWS에 github action을 이용하여 [blog] 브랜치에 push할 때 블로그 서비스 자동 배포
blog 브랜치에 머지하는 PR을 남길 때 빌드, Lint 테스트 자동화

📘Ref.
https://docs.aws.amazon.com/route53/
https://docs.aws.amazon.com/s3/
https://docs.aws.amazon.com/cloudfront/
https://docs.aws.amazon.com/acm/
https://docs.aws.amazon.com/iam/
https://docs.github.com/en/actions
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions

✅ Route53 도메인 설정

sungwook.dev DNS 설정
서브 도메인 생성
✅ S3 버킷 설정

서울 Region으로 생성
정적 웹사이트 호스팅 활성화
✅ SSL 인증서 생성 (Certificate Manager)

us-east-1 Region에서 생성
sungwook.dev, *.sungwook.dev 도메인 인증서 생성
✅ CloudFront 설정

S3 엔드포인트 설정
HTTP only 프로토콜 (정적 호스팅, Allow GET, HEAD)
Alternate Domain - blog.sungwook.dev 설정
생성한 SSL 인증서 선택
✅ IAM 계정 추가

배포 관련 필요한 권한만 부여
✅ Github Actions 설정

시크릿 키 추가
blog 브랜치에 push하면 자동 배포
PR 생성시 테스트 자동화
캐싱은 현재 단계에서 불필요해서 제거

closes #4 